### PR TITLE
Fixed 'something went wrong' toast appearing on tab switch (#1x0k51t)

### DIFF
--- a/src/views/Picklists.vue
+++ b/src/views/Picklists.vue
@@ -53,7 +53,7 @@ export default defineComponent({
   ionViewDidEnter() {
     this.store.dispatch('picklist/findPickList').catch(err =>
       this.store.dispatch('picklist/clearPicklist')
-    ) 
+    )
   },
   setup(){
     const store = useStore();

--- a/src/views/Picklists.vue
+++ b/src/views/Picklists.vue
@@ -51,9 +51,11 @@ export default defineComponent({
     })
   },
   updated () {
-    this.store.dispatch('picklist/findPickList').catch(err =>
-      this.store.dispatch('picklist/clearPicklist')
-    )
+    if(this.$route.path != "/tabs/settings") {
+      this.store.dispatch('picklist/findPickList').catch(err =>
+        this.store.dispatch('picklist/clearPicklist')
+      ) 
+    }
   },
   setup(){
     const store = useStore();

--- a/src/views/Picklists.vue
+++ b/src/views/Picklists.vue
@@ -51,9 +51,9 @@ export default defineComponent({
     })
   },
   ionViewDidEnter() {
-      this.store.dispatch('picklist/findPickList').catch(err =>
-        this.store.dispatch('picklist/clearPicklist')
-      ) 
+    this.store.dispatch('picklist/findPickList').catch(err =>
+      this.store.dispatch('picklist/clearPicklist')
+    ) 
   },
   setup(){
     const store = useStore();

--- a/src/views/Picklists.vue
+++ b/src/views/Picklists.vue
@@ -50,12 +50,10 @@ export default defineComponent({
       picklists: 'picklist/getPicklists'
     })
   },
-  updated () {
-    if(this.$route.path != "/tabs/settings") {
+  ionViewDidEnter() {
       this.store.dispatch('picklist/findPickList').catch(err =>
         this.store.dispatch('picklist/clearPicklist')
       ) 
-    }
   },
   setup(){
     const store = useStore();


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #83

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed toast appearing when switching tabs. The toast was caused by the findPickilist action being called globally, on all routes, stating there are no picklists. Hence, made the action to not be called on the settings route.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)