### PR TITLE
Fixed: picker name missing for some picklists

### DIFF
--- a/src/store/modules/party/actions.ts
+++ b/src/store/modules/party/actions.ts
@@ -16,7 +16,7 @@ const actions: ActionTree<PartyState, RootState> = {
     const params = {
       "inputFields": {
         "partyId": unavailablePickersPartyIds,
-        "userPartyId_op": 'in'
+        "partyId_op": 'in'
       },
       "fieldList": ["firstName", "lastName", "partyId"],
       "entityName": "PartyNameView",

--- a/src/store/modules/party/actions.ts
+++ b/src/store/modules/party/actions.ts
@@ -19,7 +19,7 @@ const actions: ActionTree<PartyState, RootState> = {
         "userPartyId_op": 'in'
       },
       "fieldList": ["firstName", "lastName", "partyId"],
-      "entityName": "PartyAndUserLoginAndPerson",
+      "entityName": "PartyNameView",
       "viewSize": unavailablePickersPartyIds.length,
       "distinct": "Y",
       "noConditionFind": "Y"


### PR DESCRIPTION
Used PartyNameView entity for fetching party data. When there is no user login existing view doesn't have data.


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)