### PR TITLE
Improved: Highlight scanned item  (#127)

### DIFF
--- a/src/components/Picklist-detail-item.vue
+++ b/src/components/Picklist-detail-item.vue
@@ -1,5 +1,5 @@
 <template>
-  <ion-item v-bind:key="picklist.productId" v-for="picklist in picklists"  @click="picklist.isChecked = !picklist.isChecked" lines="none" >
+  <ion-item :class="picklist.productId === scannedProductId ? 'scanned-item' : '' " v-bind:key="picklist.productId" v-for="picklist in picklists"  @click="picklist.isChecked = !picklist.isChecked" lines="none" >
     <ion-thumbnail slot="start">
       <Image :src="getProduct(picklist.productId).mainImageUrl" />
     </ion-thumbnail>  
@@ -29,7 +29,7 @@ export default defineComponent({
     IonLabel,
     IonThumbnail
   },
-  props: ['picklists'],
+  props: ['picklists', 'scannedProductId'],
   computed: {
     ...mapGetters({
       getProduct: 'product/getProduct'
@@ -43,4 +43,10 @@ export default defineComponent({
   }
 });
 </script>
+<style scoped>
+.scanned-item {
+  background-color: var( --ion-color-medium-tint);
+}
+
+</style>
 

--- a/src/components/Picklist-detail-item.vue
+++ b/src/components/Picklist-detail-item.vue
@@ -1,5 +1,5 @@
 <template>
-  <ion-item :class="picklist.productId === scannedProductId ? 'scanned-item' : '' " v-bind:key="picklist.productId" v-for="picklist in picklists"  @click="picklist.isChecked = !picklist.isChecked" lines="none" >
+  <ion-item :id="picklist.id" :class="picklist.id === lastScannedId ? 'scanned-item' : '' " :key="picklist.id" v-for="picklist in picklists"  @click="picklist.isChecked = !picklist.isChecked" lines="none" >
     <ion-thumbnail slot="start">
       <Image :src="getProduct(picklist.productId).mainImageUrl" />
     </ion-thumbnail>  
@@ -29,7 +29,7 @@ export default defineComponent({
     IonLabel,
     IonThumbnail
   },
-  props: ['picklists', 'scannedProductId'],
+  props: ['picklists', 'lastScannedId'],
   computed: {
     ...mapGetters({
       getProduct: 'product/getProduct'
@@ -45,7 +45,7 @@ export default defineComponent({
 </script>
 <style scoped>
 .scanned-item {
-  background-color: var( --ion-color-medium-tint);
+  --background: var( --ion-color-medium-tint);
 }
 
 </style>

--- a/src/components/Picklist-detail-item.vue
+++ b/src/components/Picklist-detail-item.vue
@@ -1,16 +1,16 @@
 <template>
-  <ion-item :id="picklist.id" :class="picklist.id === lastScannedId ? 'scanned-item' : '' " :key="picklist.id" v-for="picklist in picklists"  @click="picklist.isChecked = !picklist.isChecked" lines="none" >
+  <ion-item :id="picklistItem.id" :class="picklistItem.id === lastScannedId ? 'scanned-item' : '' " :key="picklistItem.id" v-for="picklistItem in picklistItems"  @click="picklistItem.isChecked = !picklistItem.isChecked" lines="none" >
     <ion-thumbnail slot="start">
-      <Image :src="getProduct(picklist.productId).mainImageUrl" />
+      <Image :src="getProduct(picklistItem.productId).mainImageUrl" />
     </ion-thumbnail>  
     <ion-label>
-      <p class="caption">{{ getProduct(picklist.productId).parentProductName}}</p>
-      <h2>{{ getProduct(picklist.productId).productName}}</h2>
-      <h2>{{ picklist.productId }}</h2>
-      <p>{{ $t("Color") }} : {{ $filters.getFeatures(getProduct(picklist.productId).featureHierarchy, '1/COLOR/') }}</p>
-      <p>{{ $t("Size") }} : {{ $filters.getFeatures(getProduct(picklist.productId).featureHierarchy, '1/SIZE/') }}</p>
+      <p class="caption">{{ getProduct(picklistItem.productId).parentProductName}}</p>
+      <h2>{{ getProduct(picklistItem.productId).productName}}</h2>
+      <h2>{{ picklistItem.productId }}</h2>
+      <p>{{ $t("Color") }} : {{ $filters.getFeatures(getProduct(picklistItem.productId).featureHierarchy, '1/COLOR/') }}</p>
+      <p>{{ $t("Size") }} : {{ $filters.getFeatures(getProduct(picklistItem.productId).featureHierarchy, '1/SIZE/') }}</p>
     </ion-label>
-    <ion-checkbox :modelValue="picklist.isChecked" slot="end" />
+    <ion-checkbox :modelValue="picklistItem.isChecked" slot="end" />
   </ion-item>
 </template>
 
@@ -29,7 +29,7 @@ export default defineComponent({
     IonLabel,
     IonThumbnail
   },
-  props: ['picklists', 'lastScannedId'],
+  props: ['picklistItems', 'lastScannedId'],
   computed: {
     ...mapGetters({
       getProduct: 'product/getProduct'

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -33,6 +33,7 @@
   "Picklists": "Picklists",
   "Please allow camera access in your settings": "Please allow camera access in your settings",
   "Product not found": "Product not found",
+  "Product not found in remaining items": "Product not found in remaining items",
   "Scan": "Scan",
   "Select all" : "Select all",
   "Search time zones": "Search time zones",

--- a/src/store/modules/picklist/actions.ts
+++ b/src/store/modules/picklist/actions.ts
@@ -34,7 +34,6 @@ const actions: ActionTree<PicklistState, RootState> = {
         list = resp.data.docs;
         const pickersPartyIds = [...new Set(list.map((item: any) => item.partyId))]
         const pickersDetails = await dispatch('party/getPickersDetails', pickersPartyIds, { root: true });
-        
         list = list.map((item: any) => ({ ...item, pickersFullName: pickersDetails[item.partyId].fullName }))
         if (payload.viewIndex > 0) list = state.picklist.list.concat(list);
       }
@@ -107,7 +106,7 @@ const actions: ActionTree<PicklistState, RootState> = {
     try {
       resp = await PicklistService.getPicklist(params);
       if (!hasError(resp) && resp.data.count) {
-        const pickingItemList = resp.data.docs.map((picklist: any) => ({ ...picklist, isChecked: false }))
+        const pickingItemList = resp.data.docs.map((picklist: any, index: any) => ({ id: index, ...picklist, isChecked: false }))
 
         current = { picklistId: payload.id, statusId:  pickingItemList[0].statusId, pickingItemList }
         commit(types.PICKLIST_CURRENT_UPDATED, current)

--- a/src/views/Picklist-Detail.vue
+++ b/src/views/Picklist-Detail.vue
@@ -10,7 +10,7 @@
       </ion-toolbar>
     </ion-header>
     <ion-content>
-      <ion-item>
+      <ion-item class="scanner">
         <ion-label>{{ $t("Scan") }}</ion-label>  
         <ion-input @ionFocus="selectSearchBarText($event)" :placeholder="$t('product barcode')" @keyup.enter="$event.target.value && selectProduct($event.target.value.trim())"/>
       </ion-item>
@@ -209,11 +209,16 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.scanner {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
 .footer-buttons {
   gap: 5px;
   padding: 0 5px;
 }
-
 
 .action-button {
   flex: 1 100%;

--- a/src/views/Picklist-Detail.vue
+++ b/src/views/Picklist-Detail.vue
@@ -17,9 +17,9 @@
       <ion-list>
         <ion-item-group v-for="picklist in picklistGroup" :key="picklist.sortBy" >
           <ion-item-divider>
-            <ion-label> {{ picklist.sortBy }}</ion-label>
+            <ion-label> {{ picklist.sortBy }} {{ scannedProductId }}</ion-label>
           </ion-item-divider>
-          <PicklistDetailItem :picklists="picklist.record"/>
+          <PicklistDetailItem :scannedProductId="scannedProductId" :picklists="picklist.record"/>
         </ion-item-group>
       </ion-list>
      </ion-content>
@@ -98,7 +98,8 @@ export default defineComponent({
   },
   data() {
     return {
-      picklistGroup: []
+      picklistGroup: [],
+      scannedProductId: ''
     }
   },
   props: ['id'],
@@ -154,6 +155,7 @@ export default defineComponent({
       const item = this.picklist.pickingItemList.find((product) => product.productId === productId)
       if (item) {
         item.isChecked = true;
+        this.scannedProductId = item.productId
       } else {
         showToast(translate("Product not found"))
       }
@@ -207,6 +209,7 @@ export default defineComponent({
   gap: 5px;
   padding: 0 5px;
 }
+
 
 .action-button {
   flex: 1 100%;

--- a/src/views/Picklist-Detail.vue
+++ b/src/views/Picklist-Detail.vue
@@ -17,7 +17,7 @@
       <ion-list>
         <ion-item-group v-for="picklist in picklistGroup" :key="picklist.sortBy" >
           <ion-item-divider>
-            <ion-label> {{ picklist.sortBy }} {{ scannedProductId }}</ion-label>
+            <ion-label> {{ picklist.sortBy }}</ion-label>
           </ion-item-divider>
           <PicklistDetailItem :scannedProductId="scannedProductId" :picklists="picklist.record"/>
         </ion-item-group>

--- a/src/views/Picklist-Detail.vue
+++ b/src/views/Picklist-Detail.vue
@@ -19,7 +19,7 @@
           <ion-item-divider>
             <ion-label> {{ picklist.sortBy }}</ion-label>
           </ion-item-divider>
-          <PicklistDetailItem :lastScannedId="lastScannedId" :picklists="picklist.record"/>
+          <PicklistDetailItem :lastScannedId="lastScannedId" :picklistItems="picklist.record"/>
         </ion-item-group>
       </ion-list>
      </ion-content>

--- a/src/views/Picklist-Detail.vue
+++ b/src/views/Picklist-Detail.vue
@@ -19,7 +19,7 @@
           <ion-item-divider>
             <ion-label> {{ picklist.sortBy }}</ion-label>
           </ion-item-divider>
-          <PicklistDetailItem :scannedProductId="scannedProductId" :picklists="picklist.record"/>
+          <PicklistDetailItem :lastScannedId="lastScannedId" :picklists="picklist.record"/>
         </ion-item-group>
       </ion-list>
      </ion-content>
@@ -99,7 +99,7 @@ export default defineComponent({
   data() {
     return {
       picklistGroup: [],
-      scannedProductId: ''
+      lastScannedId: ''
     }
   },
   props: ['id'],
@@ -152,12 +152,16 @@ export default defineComponent({
 
       if (!productId) return;
 
-      const item = this.picklist.pickingItemList.find((product) => product.productId === productId)
+      const item = this.picklist.pickingItemList.find((product) => product.productId === productId && !product.isChecked)
       if (item) {
         item.isChecked = true;
-        this.scannedProductId = item.productId
+        this.lastScannedId = item.id;
+        // Highlight specific element
+        const scannedElement = document.getElementById(item.id);
+        scannedElement && (scannedElement.scrollIntoView());
       } else {
-        showToast(translate("Product not found"))
+        this.lastScannedId = "";
+        showToast(translate("Product not found in remaining items"))
       }
     },
     selectAll() {


### PR DESCRIPTION
Pickers should be able to easily tell what item on a picklist they've scanned when moving through many items.

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #127

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)