### PR TITLE
Implemented: scanner modal closes on pressing browser back button on the picklist detail page

### DIFF
--- a/src/views/Picklist-Detail.vue
+++ b/src/views/Picklist-Detail.vue
@@ -67,7 +67,7 @@ import { mapGetters, useStore } from 'vuex';
 import { translate } from '@/i18n'
 import { showToast } from '@/utils';
 import Scanner from '@/components/Scanner'
-import { useRouter } from 'vue-router';
+import { useRouter, onBeforeRouteLeave } from 'vue-router';
 
 export default defineComponent({
   name: 'PicklistDetail',
@@ -197,6 +197,10 @@ export default defineComponent({
   setup() {
     const store = useStore();
     const router = useRouter();
+    
+    onBeforeRouteLeave((to, from) => {
+      modalController.dismiss({dismissed: true});
+    })
       
     return {
       barcodeOutline,


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #128

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Solution - we can use an in-component navigation guard with a setup function in the picklist detail page and when the user moves away from the current route we can close the modal using the guard.

Changed Behaviour will be - If the user opens the scanner modal and clicks on the browser back button in the picklist detail page then the user moves to the previous page and modal closes.



### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)