### PR TITLE
Fixed: filter options not opening when navigating back from details page(#196)

### DIFF
--- a/src/views/Picklists.vue
+++ b/src/views/Picklists.vue
@@ -1,6 +1,6 @@
 <template>
   <ion-page>
-    <PicklistFilters content-id="filter-content" />
+    <PicklistFilters v-if="router.currentRoute.value.path === '/tabs/picklists'" content-id="filter-content" />
     <ion-header :translucent="true">
       <ion-toolbar>
         <ion-title>{{ $t("Picklists") }}</ion-title>
@@ -61,6 +61,7 @@ import { filterOutline } from 'ionicons/icons';
 import PicklistItem from '@/components/Picklist-item.vue';
 import { mapGetters, useStore } from 'vuex';
 import PicklistFilters from '@/components/Picklist-filters.vue';
+import { useRouter } from 'vue-router';
 
 export default defineComponent({
   name: 'Picklists',
@@ -120,9 +121,11 @@ export default defineComponent({
   },
   setup(){
     const store = useStore();
+    const router = useRouter();
 
     return {
       filterOutline,
+      router,
       store
     }
   }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #196

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added conditional rendering on PicklistFitler on the picklists page using the help of v-if.

V-if destroys the ion-menu when we navigate to the picklist details page and re-render it when we navigate back to the picklists page from the details. This way the ion-menu on re-rendering gets automatically enabled.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)