### PR TITLE
Fixed: Only icon is visible for the completed picklist items (#222)

### DIFF
--- a/src/components/Picklist-detail-item.vue
+++ b/src/components/Picklist-detail-item.vue
@@ -3,7 +3,7 @@
     <ion-thumbnail slot="start">
       <DxpShopifyImg :src="getProduct(picklistItem.productId).mainImageUrl" size="small" />
     </ion-thumbnail>  
-    <ion-checkbox v-if="picklistItem.statusId !== 'PICKLIST_COMPLETED' && picklistItem.statusId !== 'PICKLIST_PICKED'" :modelValue="picklistItem.isChecked"/>
+    <ion-checkbox slot="end" aria-label="checkbox" v-if="picklistItem.statusId !== 'PICKLIST_COMPLETED' && picklistItem.statusId !== 'PICKLIST_PICKED'" :modelValue="picklistItem.isChecked"/>
       <ion-label>
         <p class="caption">{{ getProduct(picklistItem.productId).parentProductName}}</p>
         <h2>{{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(picklistItem.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(picklistItem.productId)) : getProduct(picklistItem.productId).productName }}</h2>

--- a/src/components/Picklist-detail-item.vue
+++ b/src/components/Picklist-detail-item.vue
@@ -3,7 +3,7 @@
     <ion-thumbnail slot="start">
       <DxpShopifyImg :src="getProduct(picklistItem.productId).mainImageUrl" size="small" />
     </ion-thumbnail>  
-    <ion-checkbox v-if="picklistItem.statusId !== 'PICKLIST_COMPLETED' && picklistItem.statusId !== 'PICKLIST_PICKED'" :modelValue="picklistItem.isChecked">
+    <ion-checkbox v-if="picklistItem.statusId !== 'PICKLIST_COMPLETED' && picklistItem.statusId !== 'PICKLIST_PICKED'" :modelValue="picklistItem.isChecked"/>
       <ion-label>
         <p class="caption">{{ getProduct(picklistItem.productId).parentProductName}}</p>
         <h2>{{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(picklistItem.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(picklistItem.productId)) : getProduct(picklistItem.productId).productName }}</h2>
@@ -11,7 +11,6 @@
         <p>{{ $t("Color") }} : {{ $filters.getFeatures(getProduct(picklistItem.productId).featureHierarchy, '1/COLOR/') }}</p>
         <p>{{ $t("Size") }} : {{ $filters.getFeatures(getProduct(picklistItem.productId).featureHierarchy, '1/SIZE/') }}</p>
       </ion-label>
-    </ion-checkbox>
   </ion-item>
 </template>
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#222 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- The code was written in such a way that there were checks on the checkbox to be shown when picklist is not completed, meaning when the `picklistItem.statusId !== 'PICKLIST_COMPLETED' && picklistItem.statusId !== 'PICKLIST_PICKED`, in these conditions we do not want to show the checkbox.
-  but the label that contains the product details ( which is to be shown in all cases) was enclosed with checkbox, so every time we wanted not to show the checkbox, the label didn't showed either.
- To fix this i separated markup so the label shows up just like product icon/thumbnail independently in all cases.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 06-03-25 10:55:08 AM IST.webm](https://github.com/user-attachments/assets/1eb94c24-809f-459d-97bb-9f2b6f06abbf)



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/picking#contribution-guideline)