### PR TITLE
Fixed: Picklist filters and sorting on picklist items are not working once a picklist is marked as completed (#223)

### DIFF
--- a/src/components/Picklist-filters.vue
+++ b/src/components/Picklist-filters.vue
@@ -1,5 +1,5 @@
 <template>
-  <ion-menu menu-id="filters-menu" side="end" content-id="main-content" type="overlay">
+  <ion-menu side="end" content-id="main-content" type="overlay">
     <ion-header>
       <ion-toolbar>
         <ion-title>{{ $t("Filters") }}</ion-title>

--- a/src/views/Picklists.vue
+++ b/src/views/Picklists.vue
@@ -1,6 +1,6 @@
 <template>
   <ion-page>
-    <PicklistFilters v-if="router.currentRoute.value.path === '/tabs/picklists'" content-id="filter-content" />
+    <PicklistFilters menu-id="filters-menu" v-if="router.currentRoute.value.path === '/tabs/picklists'" content-id="filter-content" />
     <ion-header :translucent="true">
       <ion-toolbar>
         <ion-title>{{ $t("Picklists") }}</ion-title>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#223 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
added `menu-id` prop on ion-menu and `menu` prop on ion-menu-button to map menu with respective button solving the issue of menu buttons not opening menu causing the root issue.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/picking#contribution-guideline)